### PR TITLE
Redirect login failures to the real login page.

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
 class LoginController extends Controller
@@ -40,5 +41,14 @@ class LoginController extends Controller
     public function username()
     {
         return 'name';
+    }
+
+    protected function sendFailedLoginResponse(Request $request)
+    {
+        return redirect('/login')
+            ->withInput($request->only($this->username(), 'remember'))
+            ->withErrors([
+                $this->username() => trans('auth.failed'),
+            ]);
     }
 }


### PR DESCRIPTION
This was an issue that was annoying me while working on this in software engineering. Incorrect login credentials in the navbar now simply redirect to the login page. This means validation errors are more nicely presented and we can have a way to reset passwords more easily.