### PR TITLE
Move key decrypt to deployment script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,8 @@ before_script:
 - php artisan key:generate
 script:
 - vendor/bin/phpunit
-before_install:
-- openssl aes-256-cbc -K $encrypted_c1928afcd687_key -iv $encrypted_c1928afcd687_iv
-  -in .travis/id_travis.enc -out /tmp/id_travis -d
-- eval "$(ssh-agent -s)"
-- chmod 600 /tmp/id_travis
-- ssh-add /tmp/id_travis
 deploy:
   provider: script
-  script: bash scripts/deploy.sh
+  script: bash scripts/travis-deploy.sh
   on:
     tags: true

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+# decrypt our ssh key
+openssl aes-256-cbc -K $encrypted_c1928afcd687_key -iv $encrypted_c1928afcd687_iv
+-in .travis/id_travis.enc -out /tmp/id_travis -d
+eval "$(ssh-agent -s)"
+chmod 600 /tmp/id_travis
+ssh-add /tmp/id_travis
+
 # push to the server (we add the key to before-install
 git config --global push.default matching
 git remote add deploy ssh://git@$IP:$PORT$DEPLOY_DIR


### PR DESCRIPTION
PR tests don't have access to the environment variables needed to
decrypt the SSH key we use for deployment, so their builds will always
fail. Since we only need that key at deploy time, we can defer on
decrypting until that time. This commit also renames the deployment
script to make it more clear that it's intended for travis only.